### PR TITLE
 Fix: Handle IRC and tox group /me actions properly

### DIFF
--- a/src/callbacks/tox_callbacks.c
+++ b/src/callbacks/tox_callbacks.c
@@ -61,7 +61,7 @@ static void friend_message_callback(Tox *tox, uint32_t fid, TOX_MESSAGE_TYPE typ
     }
 }
 
-static void group_message_callback(Tox *tox, uint32_t groupnumber, uint32_t peer_number, TOX_MESSAGE_TYPE UNUSED(type),
+static void group_message_callback(Tox *tox, uint32_t groupnumber, uint32_t peer_number, TOX_MESSAGE_TYPE type,
                                    const uint8_t *message, size_t length, void *userdata) {
 
     if (tox_conference_peer_number_is_ours(tox, groupnumber, peer_number, NULL)) {
@@ -151,7 +151,12 @@ static void group_message_callback(Tox *tox, uint32_t groupnumber, uint32_t peer
 
             snprintf(buffer, buffer_size, "<%s> %s", name, message_line);
 
-            irc_send_message(irc, channel, buffer);
+            if (type == TOX_MESSAGE_TYPE_ACTION)
+            {
+                irc_send_action_message(irc, channel, buffer);
+            } else {
+                irc_send_message(irc, channel, buffer);
+            }
 
             next_character = i + 1;
 

--- a/src/irc.c
+++ b/src/irc.c
@@ -206,6 +206,10 @@ int irc_send_message(IRC *irc, char *channel, char *msg) {
     return network_send_fmt(irc->sock, "PRIVMSG %s :%s\n", channel, msg);
 }
 
+int irc_send_action_message(IRC *irc, char *channel, char *msg) {
+    return network_send_fmt(irc->sock, "PRIVMSG %s :\001ACTION %s\001\n", channel, msg);
+}
+
 uint32_t irc_get_channel_index(const IRC *irc, const char *channel) {
     for (uint32_t i = 0; i < irc->num_channels; i++) {
         if (strcmp(channel, irc->channels[i].name) == 0) {

--- a/src/irc.h
+++ b/src/irc.h
@@ -110,6 +110,11 @@ void irc_leave_all_channels(IRC *irc);
 int irc_send_message(IRC *irc, char *channel, char *msg);
 
 /*
+ * Sends the specified action message to the specified channel
+ */
+int irc_send_action_message(IRC *irc, char *channel, char *msg);
+
+/*
  * Frees the IRC struct and irc->channels.
  * If the connection hasn't been closed it will also disconnect from the IRC
  * server

--- a/src/tox.c
+++ b/src/tox.c
@@ -70,9 +70,26 @@ bool tox_connect(Tox *tox) {
 }
 
 void tox_group_send_msg(Tox *tox, uint32_t group_num, char *nick, char *msg) {
-    char   message[TOX_MAX_MESSAGE_LENGTH];
-    size_t length = snprintf(message, sizeof(message), "<%s> %s", nick, msg);
-    tox_conference_send_message(tox, group_num, TOX_MESSAGE_TYPE_NORMAL, (uint8_t *)message, length, NULL);
+    //If incoming IRC message is an action send an action in the tox group/conference
+    if (strncmp("\001ACTION", msg, 7) == 0) {
+
+        msg[strlen(msg)-1] = '\0';
+        msg+=8;
+
+        char   message[TOX_MAX_MESSAGE_LENGTH];
+        size_t length = snprintf(message, sizeof(message), "<%s> %s", nick, msg);
+
+        tox_conference_send_message(tox, group_num, TOX_MESSAGE_TYPE_ACTION, (uint8_t *)message, length, NULL);
+
+    } else {
+
+        char   message[TOX_MAX_MESSAGE_LENGTH];
+        size_t length = snprintf(message, sizeof(message), "<%s> %s", nick, msg);
+
+        tox_conference_send_message(tox, group_num, TOX_MESSAGE_TYPE_NORMAL, (uint8_t *)message, length, NULL);
+
+    }
+
 }
 
 bool tox_is_friend_master(Tox *tox, uint32_t fid) {


### PR DESCRIPTION
Current implementation of toxirc does not handle irc actions properly and the resulting messages sent to the conference take the form of `<Guest8982> ^AACTION test^A`.
This PR focuses on implementing detection for the \001ACTION part of incoming messages and converting it to proper TOX_MESSAGE_TYPE_ACTION type of messages. It also works the other way around to send message of type TOX_MESSAGE_TYPE_ACTION to the irc channel as actions.

There is a better way of handling this but I'd like to offer at least a temporary fix.